### PR TITLE
Fix Process failed to start error

### DIFF
--- a/SlicerCaseIterator/SlicerCaseIterator.py
+++ b/SlicerCaseIterator/SlicerCaseIterator.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # =========================================================================
 #  Copyright Joost van Griethuysen
 #


### PR DESCRIPTION
Adding a Python shebang (#!/usr/bin/env python) to a Python file indicates to Slicer that it is an executable that should be run by Python as a CLI. Shebang must not be added for Python scripted modules.

This change fixes issue #3