### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,10 @@ project(SlicerCaseIterator)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information
-set(EXTENSION_HOMEPAGE "http://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/SlicerCaseIterator")
+set(EXTENSION_HOMEPAGE "https://www.slicer.org/wiki/Documentation/Nightly/Extensions/SlicerCaseIterator")
 set(EXTENSION_CATEGORY "Utilities")
 set(EXTENSION_CONTRIBUTORS "Joost van Griethuysen (AVL-NKI), Christian Herz (CHOP)")
-set(EXTENSION_DESCRIPTION "This is a scripted loadable module to iterate over a batch of images (with/without prior labelmaps) for segmentation or review.")
+set(EXTENSION_DESCRIPTION "Scripted module for iterating over a set of cases listed in a CSV file for segmentation or review.")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/JoostJM/SlicerCaseIterator/master/SlicerCaseIterator.png")
 set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/JoostJM/SlicerCaseIterator/master/SlicerCaseIterator-Screenshot.png")
 set(EXTENSION_DEPENDS "SlicerDevelopmentToolbox")


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.